### PR TITLE
Changes according to the Sprint 1 of 20220713

### DIFF
--- a/MagicCO-boot/src/main/resources/application.yml
+++ b/MagicCO-boot/src/main/resources/application.yml
@@ -20,8 +20,8 @@ ontimize:
             - OPTIONS
             - DELETE
    jdbc:
-      name-convention: upper
-      sqlhandler: hsqldb
+      name-convention: lower
+      sqlhandler: postgres
       sql-condition-processor:
          uppper-string: true
          upper-like: true
@@ -62,10 +62,10 @@ server:
       mime-types: application/json, application/xml
 spring:
    datasource:
-      driver-class-name: org.hsqldb.jdbcDriver
-      jdbc-url: jdbc:hsqldb:hsql://localhost:9013/templateDB
-      username: SA
-      password:
+      driver-class-name: org.postgresql.Driver
+      jdbc-url: jdbc:postgresql://45.84.210.174:65432/Fullstack_2022_1_G2
+      username: Fullstack_2022_1_G2
+      password: 2OA0MFMzBZJbOyam1q
       initial-size: 10
       test-on-borrow: true
    main:

--- a/MagicCO-model/pom.xml
+++ b/MagicCO-model/pom.xml
@@ -23,8 +23,8 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.hsqldb</groupId>
-			<artifactId>hsqldb</artifactId>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
 		</dependency>
 
 		<dependency>

--- a/MagicCO-model/src/main/resources/dao/ServiceDao.xml
+++ b/MagicCO-model/src/main/resources/dao/ServiceDao.xml
@@ -6,10 +6,10 @@
         catalog="" schema="${mainschema}" table="SERVICE"
         datasource="mainDataSource" sqlhandler="dbSQLStatementHandler">
     <DeleteKeys>
-        <Column>ID_SERVICE</Column>
+        <Column>id_service</Column>
     </DeleteKeys>
     <UpdateKeys>
-        <Column>ID_SERVICE</Column>
+        <Column>id_service</Column>
     </UpdateKeys>
-    <GeneratedKey>ID_SERVICE</GeneratedKey>
+    <GeneratedKey>id_service</GeneratedKey>
     </JdbcEntitySetup>

--- a/MagicCo-frontend/src/app/main/services/services-detail/services-detail.component.html
+++ b/MagicCo-frontend/src/app/main/services/services-detail/services-detail.component.html
@@ -1,43 +1,40 @@
-<o-form service="services" entity="service" keys="ID_SERVICE" header-actions="R;I;U;D" show-header-navigation="yes">
-  <o-text-input attr="ID_SERVICE" sql-type="INTEGER" enabled="no"></o-text-input>
-  <o-text-input class="input-padding" attr="NAME" fxFlex="150" required="yes"></o-text-input>
+<o-form service="services" entity="service" keys="id_service" header-actions="R;I;U;D" show-header-navigation="yes">
+  <o-text-input attr="id_service" label="{{'ID_SERVICE' | oTranslate}}" enabled="no" sql-type="integer"></o-text-input>
+  <o-text-input class="input-padding" attr="name" label="{{'NAME' | oTranslate}}" fxFlex="150" required="yes"></o-text-input>
     <o-row>
       <o-column fxFlex>
-        <o-currency-input class="input-padding" attr="PRICE" fxFlex="80" required="yes" read-only="no" min-decimal-digits="2" max-decimal-digits="2"></o-currency-input>
-        <o-image class="input-padding" fxFlex="80" id="ICON" attr="ICON" empty-image="assets/images/no-image.png" ></o-image>
+        <o-currency-input class="input-padding" attr="price" label="{{'PRICE' | oTranslate}}"fxFlex="80" required="yes" read-only="no" min-decimal-digits="2" max-decimal-digits="2"></o-currency-input>
+        <o-image class="input-padding" fxFlex="80" id='icon' attr="icon" label="{{'ICON' | oTranslate}}" empty-image="assets/images/no-image.png" ></o-image>
       </o-column>
       <o-column title-label="SERVICE_ADDITIONAL_INFORMATION" fxFlex>
-        <o-integer-input attr="FIDELITY_POINTS" label="FIDELITY_POINTS" fxFlex="80" read-only="no" required="yes" min="0">
+        <o-integer-input attr="fidelity_points" label="{{'FIDELITY_POINTS' | oTranslate}}" fxFlex="80" read-only="no" required="yes" min="0">
         </o-integer-input>
-        <o-integer-input attr="DURATION_TIME" label="DURATION_TIME" fxFlex="80" read-only="no" required="yes"  min="1" max="28">
+        <o-integer-input attr="duration_time" label="{{'DURATION_TIME' | oTranslate}}" fxFlex="80" read-only="no" required="yes"  min="1" max="28">
         </o-integer-input>
-        <o-real-input attr="EFFICIENCY_PERCENTAGE" label="EFFICIENCY_PERCENTAGE" fxFlex="80" read-only="no" required="yes" min-decimal-digits="2" min="0" max="99">
+        <o-real-input attr="efficiency_percentage" label="{{'EFFICIENCY_PERCENTAGE' | oTranslate}}" fxFlex="80" read-only="no" required="yes" min-decimal-digits="2" min="0" max="99">
         </o-real-input>
-        <o-real-input attr="SUCCESS_PERCENTAGE" label="SUCCESS_PERCENTAGE" fxFlex="80" read-only="no" required="yes" min-decimal-digits="2" min="0" max="99">
+        <o-real-input attr="success_percentage" label="{{'SUCCESS_PERCENTAGE' | oTranslate}}" fxFlex="80" read-only="no" required="yes" min-decimal-digits="2" min="0" max="99">
         </o-real-input>
       </o-column>
       <o-column title-label="SERVICE_ADDITIONAL_INFORMATION" fxFlex>
-        <o-combo attr="MAGIC_STATUS" label="{{'MAGIC_STATUS' | oTranslate}}" [static-data]="[{MAGIC_STATUS: false}, {MAGIC_STATUS: true}]"
-        value-column="MAGIC_STATUS" columns="MAGIC_STATUS" visible-columns="MAGIC_STATUS" required="yes"
+        <o-combo attr="magic_status" label="{{'MAGIC_STATUS' | oTranslate}}" [static-data]="[{magic_status: false}, {magic_status: true}]"
+        value-column="magic_status" columns="magic_status" visible-columns="magic_status" required="yes"
         fxFlex query-on-init="false" query-on-blind="true">
           <o-combo-renderer-boolean boolean-type="boolean" render-true-value="{{'YES' | oTranslate}}" render-false-value="{{'NO' | oTranslate}}"></o-combo-renderer-boolean>
         </o-combo>
-        <o-combo attr="LEGALITY_STATUS" label="{{'LEGALITY_STATUS' | oTranslate}}" [static-data]="[{LEGALITY_STATUS: false}, {LEGALITY_STATUS: true}]"
-        value-column="LEGALITY_STATUS" columns="LEGALITY_STATUS" visible-columns="LEGALITY_STATUS" required="yes"
+        <o-combo attr="legality_status" label="{{'LEGALITY_STATUS' | oTranslate}}" [static-data]="[{legality_status: false}, {legality_status: true}]"
+        value-column="legality_status" columns="legality_status" visible-columns="legality_status" required="yes"
         fxFlex query-on-init="false" query-on-blind="true">
           <o-combo-renderer-boolean boolean-type="boolean" render-true-value="{{'YES' | oTranslate}}" render-false-value="{{'NO' | oTranslate}}"></o-combo-renderer-boolean>
         </o-combo>
-        <o-combo attr="BONUS" label="{{'BONUS' | oTranslate}}" [static-data]="[{BONUS: false}, {BONUS: true}]"
-        value-column="BONUS" columns="BONUS" visible-columns="BONUS" required="yes"
+        <o-combo attr="bonus" label="{{'BONUS' | oTranslate}}" [static-data]="[{bonus: false}, {bonus: true}]"
+        value-column="bonus" columns="bonus" visible-columns="bonus" required="yes"
         fxFlex query-on-init="false" query-on-blind="true">
         <o-combo-renderer-boolean boolean-type="boolean" render-true-value="{{'YES' | oTranslate}}" render-false-value="{{'NO' | oTranslate}}"></o-combo-renderer-boolean>
         </o-combo>
       </o-column>
     </o-row>
     <o-row>
-      <o-textarea-input attr="DESCRIPTION" fxFlex></o-textarea-input>
+      <o-textarea-input attr="description" label="{{'DESCRIPTION' | oTranslate}}" fxFlex></o-textarea-input>
     </o-row>
 </o-form>
-
-
-

--- a/MagicCo-frontend/src/app/main/services/services-detail/services-detail.component.ts
+++ b/MagicCo-frontend/src/app/main/services/services-detail/services-detail.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
-import { OComboComponent, OFormComponent } from 'ontimize-web-ngx';
 
 
 @Component({

--- a/MagicCo-frontend/src/app/main/services/services-home/services-home.component.html
+++ b/MagicCo-frontend/src/app/main/services/services-home/services-home.component.html
@@ -1,14 +1,15 @@
 <o-form-layout-manager title="SERVICES" separator=" | " mode="tab" label-columns="NAME" >
   <div fxFill>
     <o-table fxFlex attr="servicesTable" service="services" entity="service" keys="ID_SERVICE"
-      columns="ID_SERVICE;NAME;ICON;PRICE;FIDELITY_POINTS;DURATION_TIME;LEGALITY_STATUS;MAGIC_STATUS;EFFICIENCY_PERCENTAGE;SUCCESS_PERCENTAGE;BONUS;DESCRIPTION"
-      visible-columns="NAME;ICON;PRICE;FIDELITY_POINTS;DURATION_TIME;LEGALITY_STATUS;MAGIC_STATUS;EFFICIENCY_AS_PERCENTS;SUCCESS_AS_PERCENTS;BONUS;DESCRIPTION"
-      query-rows="25" auto-adjust="false" title-align="center" show-buttons-text="true" virtual-scroll="no">
-      <o-table-column attr="NAME" title="{{'NAME' | oTranslate}}" content-align="left" multiline="yes" tooltip="{{NAME}}"></o-table-column>
+      columns="ID_SERVICE;NAME;ICON;PRICE;FIDELITY_POINTS;DURATION_TIME;LEGALITY_STATUS;MAGIC_STATUS;EFFICIENCY_PERCENTAGE;SUCCESS_PERCENTAGE;BONUS"
+      visible-columns="ICON;NAME;PRICE;FIDELITY_POINTS;DURATION_TIME;LEGALITY_STATUS;MAGIC_STATUS;EFFICIENCY_AS_PERCENTS;SUCCESS_AS_PERCENTS;BONUS"
+      query-rows="25" auto-adjust="false" title-align="center" show-buttons-text="true" virtual-scroll="no"
+      detail-mode="dblclick" select-column-visible="yes" selection-mode="multiple">
       <o-table-column attr="ICON" title="{{'ICON' | oTranslate}}" avatar="yes" orderable="no" searchable="no" width="32px" >
         <o-table-cell-renderer-image image-type="base64" empty-image="assets/images/no-image.png" avatar="yes">
         </o-table-cell-renderer-image>
       </o-table-column>
+      <o-table-column attr="NAME" title="{{'NAME' | oTranslate}}" content-align="left" multiline="yes" tooltip="yes"></o-table-column>
       <o-table-column attr="PRICE" title="{{'PRICE' | oTranslate}}"  type="currency" thousand-separator="." decimal-separator=","
         currency-symbol="€" currency-symbol-position="right" title-align="center" content-align="center"></o-table-column>
       <o-table-column attr="FIDELITY_POINTS" title="{{'FIDELITY_POINTS' | oTranslate}}" title-align="center" content-align="center"></o-table-column>
@@ -19,7 +20,6 @@
       <o-table-column-calculated attr="SUCCESS_AS_PERCENTS" title="{{'SUCCESS_AS_PERCENTS' | oTranslate}}" operation="(SUCCESS_PERCENTAGE/100)"
         type="percentage" decimal-separator="," class="o-table-column-centered">
       </o-table-column-calculated>
-      <o-table-column attr="DESCRIPTION" title="{{'DESCRIPTION' | oTranslate}}" content-align="left" multiline="yes"></o-table-column>
       <o-table-column attr="LEGALITY_STATUS" title="{{'LEGALITY_STATUS' | oTranslate}}" type="boolean" true-value="check_circle"
         boolean-type="boolean" render-type="icon" render-true-value="check_circle" render-false-value="highlight_off">
       </o-table-column>

--- a/MagicCo-frontend/src/app/main/services/services-home/services-home.component.html
+++ b/MagicCo-frontend/src/app/main/services/services-home/services-home.component.html
@@ -1,32 +1,32 @@
 <o-form-layout-manager title="SERVICES" separator=" | " mode="tab" label-columns="NAME" >
   <div fxFill>
-    <o-table fxFlex attr="servicesTable" service="services" entity="service" keys="ID_SERVICE"
-      columns="ID_SERVICE;NAME;ICON;PRICE;FIDELITY_POINTS;DURATION_TIME;LEGALITY_STATUS;MAGIC_STATUS;EFFICIENCY_PERCENTAGE;SUCCESS_PERCENTAGE;BONUS"
-      visible-columns="ICON;NAME;PRICE;FIDELITY_POINTS;DURATION_TIME;LEGALITY_STATUS;MAGIC_STATUS;EFFICIENCY_AS_PERCENTS;SUCCESS_AS_PERCENTS;BONUS"
+    <o-table fxFlex attr="servicesTable" service="services" entity="service" keys="id_service"
+    columns="id_service;name;icon;price;fidelity_points;duration_time;legality_status;magic_status;efficiency_percentage;success_percentage;bonus"
+    visible-columns="icon;name;price;fidelity_points;duration_time;legality_status;magic_status;efficiency_as_percents;success_as_percents;bonus"
       query-rows="25" auto-adjust="false" title-align="center" show-buttons-text="true" virtual-scroll="no"
       detail-mode="dblclick" select-column-visible="yes" selection-mode="multiple">
-      <o-table-column attr="ICON" title="{{'ICON' | oTranslate}}" avatar="yes" orderable="no" searchable="no" width="32px" >
+      <o-table-column attr="icon" title="{{'ICON' | oTranslate}}" avatar="yes" orderable="no" searchable="no" width="32px" >
         <o-table-cell-renderer-image image-type="base64" empty-image="assets/images/no-image.png" avatar="yes">
         </o-table-cell-renderer-image>
       </o-table-column>
-      <o-table-column attr="NAME" title="{{'NAME' | oTranslate}}" content-align="left" multiline="yes" tooltip="yes"></o-table-column>
-      <o-table-column attr="PRICE" title="{{'PRICE' | oTranslate}}"  type="currency" thousand-separator="." decimal-separator=","
+      <o-table-column attr="name" title="{{'NAME' | oTranslate}}" content-align="left" multiline="yes" tooltip="yes"></o-table-column>
+      <o-table-column attr="price" title="{{'PRICE' | oTranslate}}"  type="currency" thousand-separator="." decimal-separator=","
         currency-symbol="€" currency-symbol-position="right" title-align="center" content-align="center"></o-table-column>
-      <o-table-column attr="FIDELITY_POINTS" title="{{'FIDELITY_POINTS' | oTranslate}}" title-align="center" content-align="center"></o-table-column>
-      <o-table-column attr="DURATION_TIME" title="{{'DURATION_TIME' | oTranslate}}" title-align="center" content-align="center"></o-table-column>
-      <o-table-column-calculated attr="EFFICIENCY_AS_PERCENTS" title="{{'EFFICIENCY_AS_PERCENTS' | oTranslate}}" [operation-function]="showNumberAsPercents"
+      <o-table-column attr="fidelity_points" title="{{'FIDELITY_POINTS' | oTranslate}}" title-align="center" content-align="center"></o-table-column>
+      <o-table-column attr="duration_time" title="{{'DURATION_TIME' | oTranslate}}" title-align="center" content-align="center"></o-table-column>
+      <o-table-column-calculated attr="efficiency_as_percents" title="{{'EFFICIENCY_AS_PERCENTS' | oTranslate}}" [operation-function]="showNumberAsPercents"
         type="percentage" decimal-separator="," class="o-table-column-centered" >
       </o-table-column-calculated>
-      <o-table-column-calculated attr="SUCCESS_AS_PERCENTS" title="{{'SUCCESS_AS_PERCENTS' | oTranslate}}" operation="(SUCCESS_PERCENTAGE/100)"
+      <o-table-column-calculated attr="success_as_percents" title="{{'SUCCESS_AS_PERCENTS' | oTranslate}}" operation="(success_percentage/100)"
         type="percentage" decimal-separator="," class="o-table-column-centered">
       </o-table-column-calculated>
-      <o-table-column attr="LEGALITY_STATUS" title="{{'LEGALITY_STATUS' | oTranslate}}" type="boolean" true-value="check_circle"
+      <o-table-column attr="legality_status" title="{{'LEGALITY_STATUS' | oTranslate}}" type="boolean" true-value="check_circle"
         boolean-type="boolean" render-type="icon" render-true-value="check_circle" render-false-value="highlight_off">
       </o-table-column>
-      <o-table-column attr="MAGIC_STATUS" title="{{'MAGIC_STATUS' | oTranslate}}" type="boolean" true-value="check_circle"
+      <o-table-column attr="magic_status" title="{{'MAGIC_STATUS' | oTranslate}}" type="boolean" true-value="check_circle"
         boolean-type="boolean" render-type="icon" render-true-value="check_circle" render-false-value="highlight_off">
       </o-table-column>
-      <o-table-column attr="BONUS" title="{{'BONUS' | oTranslate}}" type="boolean" true-value="check_circle"
+      <o-table-column attr="bonus" title="{{'BONUS' | oTranslate}}" type="boolean" true-value="check_circle"
         boolean-type="boolean" render-type="icon" render-true-value="check_circle" render-false-value="highlight_off">
       </o-table-column>
     </o-table>

--- a/MagicCo-frontend/src/app/main/services/services-new/services-new.component.html
+++ b/MagicCo-frontend/src/app/main/services/services-new/services-new.component.html
@@ -1,36 +1,36 @@
-<o-form service="services" entity="service" keys="ID_SERVICE" header-actions="R;I;U;D" show-header-navigation="no">
-  <o-text-input class="input-padding" attr="NAME" fxFlex="150" required="yes"></o-text-input>
+<o-form service="services" entity="service" keys="id_service" header-actions="R;I;U;D" show-header-navigation="no">
+  <o-text-input class="input-padding" attr="name" label="{{'NAME' | oTranslate}}" fxFlex="150" required="yes"></o-text-input>
     <o-row>
       <o-column fxFlex>
-        <o-currency-input class="input-padding" attr="PRICE" fxFlex="80" required="yes" read-only="no" min-decimal-digits="2" max-decimal-digits="2"></o-currency-input>
+        <o-currency-input class="input-padding" attr="price" label="{{'PRICE' | oTranslate}}" fxFlex="80" required="yes" read-only="no" min-decimal-digits="2" max-decimal-digits="2"></o-currency-input>
         <o-image class="input-padding" fxFlex="80" id="ICON" attr="ICON" empty-image="assets/images/no-image.png"></o-image>
       </o-column>
       <o-column title-label="SERVICE_ADDITIONAL_INFORMATION" fxFlex>
-        <o-integer-input attr="FIDELITY_POINTS" label="FIDELITY_POINTS" fxFlex="80" read-only="no" required="yes" min="0">
+        <o-integer-input attr="fidelity_points" label="{{'FIDELITY_POINTS' | oTranslate}}" fxFlex="80" read-only="no" required="yes" min="0">
         </o-integer-input>
-        <o-integer-input attr="DURATION_TIME" label="DURATION_TIME" fxFlex="80" read-only="no" required="yes"  min="1" max="28">
+        <o-integer-input attr="duration_time" label="{{'DURATION_TIME' | oTranslate}}" fxFlex="80" read-only="no" required="yes"  min="1" max="28">
         </o-integer-input>
-        <o-real-input attr="EFFICIENCY_PERCENTAGE" label="EFFICIENCY_PERCENTAGE" fxFlex="80" read-only="no" required="yes" min-decimal-digits="2" min="0" max="99">
+        <o-real-input attr="efficiency_percentage" label="{{'EFFICIENCY_PERCENTAGE' | oTranslate}}" fxFlex="80" read-only="no" required="yes" min-decimal-digits="2" min="0" max="99">
         </o-real-input>
-        <o-real-input attr="SUCCESS_PERCENTAGE" label="SUCCESS_PERCENTAGE" fxFlex="80" read-only="no" required="yes" min-decimal-digits="2" min="0" max="99">
+        <o-real-input attr="success_percentage" label="{{'SUCCESS_PERCENTAGE' | oTranslate}}" fxFlex="80" read-only="no" required="yes" min-decimal-digits="2" min="0" max="99">
         </o-real-input>
       </o-column>
       <o-column title-label="SERVICE_ADDITIONAL_INFORMATION" fxFlex>
-        <o-combo attr="LEGALITY_STATUS" [static-data]="booleanArray" [data]="selectedBooleanString"
+        <o-combo attr="legality_status" label="{{'LEGALITY_STATUS' | oTranslate}}" [static-data]="booleanArray" [data]="selectedBooleanString"
           value-column="booleanString" columns="booleanString;booleanValue" visible-columns="booleanValue"
           required="yes" fxFlex>
           <o-combo-renderer-boolean boolean-type="string" true-value="true" false-value="false"
           render-true-value="{{'YES' | oTranslate}}" render-false-value="{{'NO' | oTranslate}}">
           </o-combo-renderer-boolean>
         </o-combo>
-        <o-combo attr="MAGIC_STATUS" [static-data]="booleanArray" [data]="selectedBooleanString"
+        <o-combo attr="magic_status" label="{{'MAGIC_STATUS' | oTranslate}}" [static-data]="booleanArray" [data]="selectedBooleanString"
           value-column="booleanString" columns="booleanString;booleanValue" visible-columns="booleanValue"
           required="yes" fxFlex>
           <o-combo-renderer-boolean boolean-type="string" true-value="true" false-value="false"
           render-true-value="{{'YES' | oTranslate}}" render-false-value="{{'NO' | oTranslate}}">
           </o-combo-renderer-boolean>
         </o-combo>
-        <o-combo attr="BONUS" [static-data]="booleanArray" [data]="selectedBooleanString"
+        <o-combo attr="bonus" label="{{'BONUS' | oTranslate}}" [static-data]="booleanArray" [data]="selectedBooleanString"
           value-column="booleanString" columns="booleanString;booleanValue" visible-columns="booleanValue"
           required="yes" fxFlex>
           <o-combo-renderer-boolean boolean-type="string" true-value="true" false-value="false"
@@ -40,7 +40,7 @@
       </o-column>
     </o-row>
     <o-row>
-      <o-textarea-input attr="DESCRIPTION" fxFlex></o-textarea-input>
+      <o-textarea-input attr="description" fxFlex></o-textarea-input>
     </o-row>
 </o-form>
 

--- a/MagicCo-frontend/src/app/main/services/services-new/services-new.component.ts
+++ b/MagicCo-frontend/src/app/main/services/services-new/services-new.component.ts
@@ -27,9 +27,4 @@ export class ServicesNewComponent implements OnInit {
 
   public selectedBooleanString = 'true';
 
-  // getValue() {
-  //   console.log(this.booleanCombo);
-  // }
-
-
 }

--- a/MagicCo-frontend/src/app/main/services/services-routing.module.ts
+++ b/MagicCo-frontend/src/app/main/services/services-routing.module.ts
@@ -15,7 +15,7 @@ const routes: Routes = [
     component: ServicesNewComponent
   },
   {
-    path: ':ID_SERVICE',
+    path: ':id_service',
     component: ServicesDetailComponent
   }
 ];

--- a/MagicCo-frontend/src/app/shared/shared.module.ts
+++ b/MagicCo-frontend/src/app/shared/shared.module.ts
@@ -4,7 +4,7 @@ import { OntimizeWebModule } from 'ontimize-web-ngx';
 
 
 export function showNumberAsPercentsFunction (rowData: Array<any>): number {
-  return rowData['EFFICIENCY_PERCENTAGE']/100;
+  return rowData['efficiency_percentage']/100;
 }
 
 @NgModule({

--- a/MagicCo-frontend/src/assets/i18n/en.json
+++ b/MagicCo-frontend/src/assets/i18n/en.json
@@ -25,7 +25,7 @@
   "NAME": "Service name",
   "PRICE": "Service price",
   "FIDELITY_POINTS": "Fidelity points",
-  "DURATION_TIME": "Duration time",
+  "DURATION_TIME": "Duration (in days)",
   "LEGALITY_STATUS": "Legal status",
   "MAGIC_STATUS": "Magic Status",
   "EFFICIENCY_PERCENTAGE": "Efficiency, %",

--- a/pom.xml
+++ b/pom.xml
@@ -75,25 +75,29 @@
     
     
     <hsqldatabase.path>src/main/db</hsqldatabase.path>
-                        
-    
-    
-    
+
+
+
+
     <database.url>jdbc:hsqldb:hsql://localhost:9013/templateDB</database.url>
-                        
-    
-    
-    
+
+
+
+
     <hsqldb.version>2.3.4</hsqldb.version>
                         
     
     
     
     <spring-boot.repackage.skip>true</spring-boot.repackage.skip>
-                    
-  
-  
-  
+
+
+
+
+    <postgresql.version>42.4.0</postgresql.version>
+
+
+
   </properties>
             
   
@@ -125,8 +129,8 @@
       
       
       </dependency>
-                                    
-      
+
+
       
       
       <dependency>
@@ -226,35 +230,38 @@
       
       
       </dependency>
-                                    
-      
-      
-      
+
+
+
+
       <dependency>
-                                                
-        
-        
-        
-        <groupId>org.hsqldb</groupId>
-                                                
-        
-        
-        
-        <artifactId>hsqldb</artifactId>
-                                                
-        
-        
-        
-        <version>${hsqldb.version}</version>
-                                            
-      
-      
-      
+
+
+
+
+        <groupId>org.postgresql</groupId>
+
+
+
+
+        <artifactId>postgresql</artifactId>
+
+
+
+
+        <version>${postgresql.version}</version>
+
+
+
       </dependency>
-                                
-    
-    
-    
+
+
+
+
+
+
+
+
     </dependencies>
                     
   


### PR DESCRIPTION
Modified in the frontend:
- columns order;
- enter the magic service details by doubleclick;
- select the row of magic service detail by click (multiple select by Ctrl or Shift + click);
- english translation.